### PR TITLE
gdb: Flush registers before connecting to a new target

### DIFF
--- a/gdb/ChangeLog.RISCV
+++ b/gdb/ChangeLog.RISCV
@@ -1,3 +1,7 @@
+2017-08-09  Andrew Burgess  <andrew.burgess@embecosm.com>
+
+	* target.c (target_preopen): Call registers_changed.
+
 2017-07-03  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
 	* riscv-tdep.c (riscv_gdbarch_init): Add

--- a/gdb/target.c
+++ b/gdb/target.c
@@ -2245,6 +2245,9 @@ target_preopen (int from_tty)
 	error (_("Program not killed."));
     }
 
+  /* Invalidate all cached registers.  */
+  registers_changed ();
+
   /* Calling target_kill may remove the target from the stack.  But if
      it doesn't (which seems like a win for UDI), remove it now.  */
   /* Leave the exec target, though.  The user may be switching from a


### PR DESCRIPTION
If we do this:

  # Spawn gdbserver
  (gdb) target remote :PORT
  (gdb) load
  (gdb) p/x $pc
  (gdb) monitor exit
  # Spawn a new gdbserver
  (gdb) target remote :PORT
  (gdb) load
  (gdb) flushregs
  (gdb) p/x $pc

We should expect the two printed $pc values to match, however, this is
not currently the case as the register cache is not flushed when we
connect to a new target.  When we 'load' we expect GDB to set the $pc to
be the entry point of the executable, however, with 'target remote' the
new register value is only sent across if we think is might be different
from the current register value.  So, if we have a cached $pc value that
matches the value we're trying to load, then the new $pc will not be
sent to the target.

As GDB fails to flush the register cache when starting a new target,
this is exactly what happens, the result is that in the second target
GDB does not set $pc to the entry point correctly, and bad stuff
happens.

After this commit we flush the register cache and all is good.

It would be nice to upstream this fix, however, for now I'm struggling
to find a way to reproduce this using the standard gdbserver (or any
other target) as the 'target remote' ... 'load' strategy that we're
using here is not the normal way that the "standard" gdbserver is used.

gdb/ChangeLog:

	* target.c (target_preopen): Call registers_changed.