### PR TITLE
gdb/riscv: Set long double format

### DIFF
--- a/gdb/ChangeLog.RISCV
+++ b/gdb/ChangeLog.RISCV
@@ -1,3 +1,7 @@
+2017-08-16  Andrew Burgess  <andrew.burgess@embecosm.com>
+
+	* riscv-tdep.c (riscv_gdbarch_init): Set long double format.
+
 2017-08-09  Andrew Burgess  <andrew.burgess@embecosm.com>
 
 	* target.c (target_preopen): Call registers_changed.

--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -1250,6 +1250,7 @@ riscv_gdbarch_init (struct gdbarch_info info,
   set_gdbarch_float_bit (gdbarch, 32);
   set_gdbarch_double_bit (gdbarch, 64);
   set_gdbarch_long_double_bit (gdbarch, 128);
+  set_gdbarch_long_double_format (gdbarch, floatformats_ia64_quad);
   set_gdbarch_ptr_bit (gdbarch, riscv_isa_regsize (gdbarch) * 8);
   set_gdbarch_char_signed (gdbarch, 1);
 


### PR DESCRIPTION
Set up the long double format used for Risc V, this fixes some failures
in gdb.base/store.exp.

gdb/ChangeLog:

	* riscv-tdep.c (riscv_gdbarch_init): Set long double format.